### PR TITLE
Fix: bgo #755407 stderr errors when Alt-F4 is used

### DIFF
--- a/meld/meldapp.py
+++ b/meld/meldapp.py
@@ -98,6 +98,8 @@ class MeldApp(Gtk.Application):
     def do_window_removed(self, widget):
         widget.meldwindow = None
         Gtk.Application.do_window_removed(self, widget)
+        if not len(self.get_windows()):
+            self.quit()
 
     # We can't override do_local_command_line because it has no introspection
     # annotations: https://bugzilla.gnome.org/show_bug.cgi?id=687912


### PR DESCRIPTION
Problem:
  When meld is launched from console, usecase is git difftool,
  After closing App using Alt+F4 console displays multiple error messages
  Error Messages look like
  (meld:18521): Gtk-CRITICAL **: gtk_container_foreach: assertion 'GTK_IS_CONTAINER (container)' failed
https://bugzilla.gnome.org/show_bug.cgi?id=755407

Cause:
  closing window triggers do_window_removed
  Unlike when Quit is choosen from Menu, self.quit() is never called
  Gtk complains and adds error messages on STDERR

Solution:
  When do_window_removed is called check if there are any active windows
  If there is no active window, call self.quit()
