### PR TITLE
added initial .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: python
+python:
+- "2.6"
+- "2.7"
+- "3.2"
+- "3.3"
+- "3.4"
+- "3.5"
+- "3.5-dev" # 3.5 development branch
+- "3.6-dev" # 3.6 development branch
+- "nightly" # currently points to 3.7-dev
+install:
+- sudo apt-get update
+- sudo apt-get build-dep --yes meld
+- sudo apt-get install --yes itstool
+    # not included into build-deps
+script:
+- python setup.py build
+- python setup.py install --prefix=$HOME


### PR DESCRIPTION
This might be useful for contributers who want to use the travis-ci.org services regardless of how you handle pull requests on github.com.