### PR TITLE
Fix for colour lookup errors

### DIFF
--- a/meld/misc.py
+++ b/meld/misc.py
@@ -187,15 +187,16 @@ def colour_lookup_with_fallback(name, attribute):
     from meld.settings import meldsettings
     source_style = meldsettings.style_scheme
 
-    style = source_style.get_style(name) if source_style else None
-    style_attr = getattr(style.props, attribute) if style else None
-    if not style or not style_attr:
+    try:
+        style = source_style.get_style(name)
+        style_attr = getattr(style.props, attribute) if style else None
+        if not style or not style_attr:
+            raise AttributeError('Style attribute not found')
+    except AttributeError:
         base_style = get_base_style_scheme()
-        try:
-            style = base_style.get_style(name)
-            style_attr = getattr(style.props, attribute)
-        except AttributeError:
-            pass
+        style = base_style.get_style(name)
+        style_attr = getattr(style.props, attribute)
+        pass
 
     if not style_attr:
         import sys


### PR DESCRIPTION
I broadened the try/catch block here to overcome a bug on my Kubuntu
16.10 system where I get a bunch of AttributeErrors... of the form:

Traceback (most recent call last):
File "/usr/lib/python2.7/dist-packages/meld/sourceview.py", line 155,
in __init__
    self.on_setting_changed(meldsettings, 'style-scheme')
File "/usr/lib/python2.7/dist-packages/meld/sourceview.py", line 181,
in on_setting_changed
    "meld:current-line-highlight", "background")
File "/usr/lib/python2.7/dist-packages/meld/misc.py", line 190, in
colour_lookup_with_fallback
    style = source_style.get_style(name)

This is probably caused by a config problem on my machine, but no harm
in making things a bit more robust right?