### PR TITLE
Prevent exception when fold compare

### DIFF
--- a/meld/diffmap.py
+++ b/meld/diffmap.py
@@ -108,7 +108,9 @@ class DiffMap(Gtk.DrawingArea):
         self._scroll_height = allocation.height
         self._width = max(allocation.width, 10)
         self._cached_map = None
-        self.queue_allocate()
+
+        try: self.queue_allocate()
+        except AttributeError: pass
 
     def do_draw(self, context):
         if not self._setup:

--- a/meld/dirdiff.py
+++ b/meld/dirdiff.py
@@ -90,13 +90,11 @@ CHUNK_SIZE = 4096
 
 
 def remove_blank_lines(text):
-	if isinstance(text, bytes): text = text.strip().decode('ISO-8859-1')
-	splits = text.splitlines()
-	lines = text.splitlines(True)
-	blanks = set([i for i, l in enumerate(splits) if not l])
-	lines = [l for i, l in enumerate(lines) if i not in blanks]
-
-	return ''.join(lines)
+    splits = text.splitlines()
+    lines = text.splitlines(True)
+    blanks = set([i for i, l in enumerate(splits) if not l])
+    lines = [l for i, l in enumerate(lines) if i not in blanks]
+    return ''.join(lines)
 
 
 def _files_same(files, regexes, comparison_args):


### PR DESCRIPTION
The DrawingArea doesn't have queue_allocate(), and it casuse a AttributeError exception when doing a folder compare.