### PR TITLE
Make replaced text highliting more contrast.

### DIFF
--- a/data/styles/meld-dark.xml
+++ b/data/styles/meld-dark.xml
@@ -3,16 +3,16 @@
   <_description>Dark color scheme for Meld highlighting</_description>
 
   <!-- Meld -->
-  <style name="meld:insert" background="#227000" foreground="#4e9a06" line-background="#309900"/>
-  <style name="meld:replace" background="#00458c" foreground="#2d6cfc" line-background="#0066cc"/>
+  <style name="meld:insert" background="#223800" foreground="#4e6206" line-background="#306100"/>
+  <style name="meld:replace" background="#003266" foreground="#1d59d6" line-background="#0053a6"/>
   <style name="meld:conflict" background="#7a2a28" foreground="#ff0000" line-background="#ac3b39"/>
   <!-- FIXME: delete background should be @theme_bg_color; line should be shaded of that -->
   <style name="meld:delete" background="#ffffff" foreground="#a40000" line-background="#cccccc"/>
   <style name="meld:error" background="#fce94f" foreground="#faad3d" line-background="#fdf8cd"/>
-  <style name="meld:inline" background="#3465a4"/>
+  <style name="meld:inline" background="#24527e"/>
   <style name="meld:current-line-highlight" background="#111100"/>
   <style name="meld:unknown-text" foreground="#aaaaaa"/>
   <style name="meld:syncpoint-outline" foreground="#bbbbbb"/>
-  <style name="meld:current-chunk-highlight" background="#rgba(255, 255, 255, 0.1)"/>
+  <style name="meld:current-chunk-highlight" background="#rgba(255, 255, 255, 0.06)"/>
   <style name="meld:dimmed" foreground="#999999"/>
 </style-scheme>


### PR DESCRIPTION
* Shift replace (blue one) and inline colors by #101326.

* Shift insert (green one) by #003800.

* Change current-chunk-highlight's alpha 0.1 -> 0.06.

https://bugzilla.gnome.org/show_bug.cgi?id=790495

**Before the patch:**
![screenshot from 2017-11-17 15-59-08](https://user-images.githubusercontent.com/14320898/32948444-498da758-cbb0-11e7-8849-439702df069d.png)

**After the patch:**
![screenshot from 2017-11-17 15-58-20](https://user-images.githubusercontent.com/14320898/32948442-495b0528-cbb0-11e7-823c-8d2cbc2bbeb8.png)

