### PR TITLE
Added support for displaying full paths

### DIFF
--- a/data/ui/dirdiff.ui
+++ b/data/ui/dirdiff.ui
@@ -114,6 +114,25 @@
                 <style>
                   <class name="meld-notebook-toolbar"/>
                 </style>
+                 <child>
+                  <object class="GtkToolItem" id="fileentry_toolitem45">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="receives_default">False</property>
+                    <child>
+                      <object class="GtkEntry" id="fileentry45">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="editable">False</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                  </packing>
+                </child>
+
                 <child>
                   <object class="GtkToolItem" id="fileentry_toolitem0">
                     <property name="visible">True</property>
@@ -130,7 +149,7 @@
                     </child>
                   </object>
                   <packing>
-                    <property name="expand">True</property>
+                    <property name="expand">False</property>
                   </packing>
                 </child>
               </object>
@@ -150,6 +169,26 @@
                 <style>
                   <class name="meld-notebook-toolbar"/>
                 </style>
+
+                <child>
+                  <object class="GtkToolItem" id="fileentry_toolitem46">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="receives_default">False</property>
+                    <child>
+                      <object class="GtkEntry" id="fileentry46">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="editable">False</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                  </packing>
+                </child>
+
                 <child>
                   <object class="GtkToolItem" id="fileentry_toolitem1">
                     <property name="visible">True</property>
@@ -166,7 +205,7 @@
                     </child>
                   </object>
                   <packing>
-                    <property name="expand">True</property>
+                    <property name="expand">False</property>
                   </packing>
                 </child>
               </object>

--- a/data/ui/filediff.ui
+++ b/data/ui/filediff.ui
@@ -410,6 +410,24 @@
                   </object>
                 </child>
                 <child>
+                  <object class="GtkToolItem" id="fileentry_toolitem466">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="receives_default">False</property>
+                    <child>
+                      <object class="GtkEntry" id="fileentry466">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="editable">False</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkToolItem" id="fileentry_toolitem1">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -423,7 +441,7 @@
                     </child>
                   </object>
                   <packing>
-                    <property name="expand">True</property>
+                    <property name="expand">False</property>
                   </packing>
                 </child>
                 <child>
@@ -480,6 +498,24 @@
                   </object>
                 </child>
                 <child>
+                  <object class="GtkToolItem" id="fileentry_toolitem455">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="receives_default">False</property>
+                    <child>
+                      <object class="GtkEntry" id="fileentry455">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="editable">False</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkToolItem" id="fileentry_toolitem0">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -493,7 +529,7 @@
                     </child>
                   </object>
                   <packing>
-                    <property name="expand">True</property>
+                    <property name="expand">False</property>
                   </packing>
                 </child>
                 <child>

--- a/meld/dirdiff.py
+++ b/meld/dirdiff.py
@@ -614,7 +614,9 @@ class DirDiff(melddoc.MeldDoc, gnomeglade.Component):
 
     def on_fileentry_file_set(self, entry):
         files = [e.get_file() for e in self.fileentry[:self.num_panes]]
-        paths = [f.get_path() for f in files]
+        paths = [f.get_path() if f is not None else f for f in files]
+        self.fileentry45.set_text(paths[0] if paths[0] else "")
+        self.fileentry46.set_text(paths[1] if paths[1] else "")
         self.set_locations(paths)
 
     def set_locations(self, locations):
@@ -624,7 +626,7 @@ class DirDiff(melddoc.MeldDoc, gnomeglade.Component):
         # the time we get this far. This is a fallback, and may be wrong!
         locations = list(locations)
         for i, l in enumerate(locations):
-            if not isinstance(l, unicode):
+            if l and not isinstance(l, unicode):
                 locations[i] = l.decode(sys.getfilesystemencoding())
         locations = [os.path.abspath(l) if l else '' for l in locations]
         self.current_path = None

--- a/meld/filediff.py
+++ b/meld/filediff.py
@@ -1029,6 +1029,9 @@ class FileDiff(melddoc.MeldDoc, gnomeglade.Component):
         if len(files) != self.num_panes:
             return
 
+        self.fileentry455.set_text(files[0] if files[0] else "")
+        self.fileentry466.set_text(files[1] if files[1] else "")
+
         self._disconnect_buffer_handlers()
         self.undosequence.clear()
         self.linediffer.clear()


### PR DESCRIPTION
Hi,

I just added draft implementation of displaying full paths, something similar to meld 1.8. 
In current version of meld, full paths are not displayed and user doesn't really know what is being compared with what.

Best regards,
Ko Cho