### PR TITLE
 Add context menu 'Copy File Names' patch 

### DIFF
--- a/meld/dirdiff.py
+++ b/meld/dirdiff.py
@@ -1365,7 +1365,7 @@ class DirDiff(Gtk.VBox, tree.TreeviewCommon, MeldDoc):
         ]
         files = [f for f in files if f]
         if files:
-            pyperclip.copy(''.join([str(f) for f in files]))
+            pyperclip.copy(' '.join([str(f) for f in files]))
 
     def action_ignore_case_change(self, action, value):
         action.set_state(value)

--- a/meld/dirdiff.py
+++ b/meld/dirdiff.py
@@ -25,6 +25,7 @@ import sys
 from collections import namedtuple
 from decimal import Decimal
 from mmap import ACCESS_COPY, mmap
+import pyperclip
 
 from gi.repository import Gdk, Gio, GLib, GObject, Gtk
 
@@ -423,6 +424,7 @@ class DirDiff(Gtk.VBox, tree.TreeviewCommon, MeldDoc):
             ('previous-change', self.action_previous_change),
             ('previous-pane', self.action_prev_pane),
             ('refresh', self.action_refresh),
+            ('copy-file-names', self.action_copy_file_names),
         )
         for name, callback in actions:
             action = Gio.SimpleAction.new(name, None)
@@ -1353,6 +1355,17 @@ class DirDiff(Gtk.VBox, tree.TreeviewCommon, MeldDoc):
         files = [f for f in files if f]
         if files:
             self._open_files(files)
+    def action_copy_file_names(self, *args):
+        pane = self._get_focused_pane()
+        if pane is None:
+            return
+        files = [
+            self.model.value_path(self.model.get_iter(p), pane)
+            for p in self._get_selected_paths(pane)
+        ]
+        files = [f for f in files if f]
+        if files:
+            pyperclip.copy(''.join([str(f) for f in files]))
 
     def action_ignore_case_change(self, action, value):
         action.set_state(value)

--- a/meld/resources/gtk/menus.ui
+++ b/meld/resources/gtk/menus.ui
@@ -38,6 +38,10 @@
         <attribute name="label" translatable="yes">Open Externally</attribute>
         <attribute name="action">view.open-external</attribute>
       </item>
+      <item>
+        <attribute name="label" translatable="yes">Copy File Names</attribute>
+        <attribute name="action">view.copy-file-names</attribute>
+      </item>
     </section>
     <section>
       <attribute name="id">find-section</attribute>

--- a/meld/resources/ui/dirdiff-menus.ui
+++ b/meld/resources/ui/dirdiff-menus.ui
@@ -40,6 +40,10 @@
         <attribute name="label" translatable="yes">_Open Externally</attribute>
         <attribute name="action">view.open-external</attribute>
       </item>
+      <item>
+        <attribute name="label" translatable="yes">_Copy File Names</attribute>
+        <attribute name="action">view.copy-file-names</attribute>
+      </item>
     </section>
   </menu>
 </interface>


### PR DESCRIPTION
Add context menu 'Copy File Names'
During directory comparison, sometimes need to copy the names  of the files to clipboard.
Needs import pyperclip.