### PR TITLE
Add FourDiff - a new way to resolve merge conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ data/mime/meld.xml
 data/org.gnome.Meld.gresource
 data/styles/meld-base.style-scheme.xml
 data/styles/meld-dark.style-scheme.xml
+
+/example/

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ data/styles/meld-base.style-scheme.xml
 data/styles/meld-dark.style-scheme.xml
 
 /example/
+/venv/

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,3 @@ data/mime/meld.xml
 data/org.gnome.Meld.gresource
 data/styles/meld-base.style-scheme.xml
 data/styles/meld-dark.style-scheme.xml
-
-/example/
-/venv/

--- a/meld/accelerators.py
+++ b/meld/accelerators.py
@@ -57,6 +57,7 @@ VIEW_ACCELERATORS: Dict[str, Union[str, Sequence[str]]] = {
     'view.vc-console-visible': 'F9',
     # Swap the two panes
     'view.swap-2-panes': '<Alt>backslash',
+    'view.toggle-fourdiff-view': '<Primary>T',
 }
 
 

--- a/meld/fourdiff.py
+++ b/meld/fourdiff.py
@@ -1,0 +1,261 @@
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or (at
+# your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import copy
+import functools
+import logging
+import math
+from enum import Enum
+from typing import Optional, Tuple, Type
+
+from gi.repository import Gdk, Gio, GLib, GObject, Gtk, GtkSource
+
+# TODO: Don't from-import whole modules
+from meld import misc
+from meld.conf import _
+from meld.const import (
+    NEWLINES,
+    TEXT_FILTER_ACTION_FORMAT,
+    ActionMode,
+    ChunkAction,
+    FileComparisonMode,
+    FileLoadError,
+)
+from meld.externalhelpers import open_files_external
+from meld.filediff import FileDiff
+from meld.gutterrendererchunk import GutterRendererChunkLines
+from meld.iohelpers import find_shared_parent_path, prompt_save_filename
+from meld.matchers.diffutil import Differ, merged_chunk_order
+from meld.matchers.helpers import CachedSequenceMatcher
+from meld.matchers.merge import AutoMergeDiffer, Merger
+from meld.meldbuffer import (
+    BufferDeletionAction,
+    BufferInsertionAction,
+    BufferLines,
+    MeldBufferState,
+)
+from meld.melddoc import ComparisonState, MeldDoc
+from meld.menuhelpers import replace_menu_section
+from meld.misc import user_critical, with_focused_pane
+from meld.patchdialog import PatchDialog
+from meld.recent import RecentType
+from meld.settings import bind_settings, get_meld_settings
+from meld.sourceview import (
+    LanguageManager,
+    TextviewLineAnimationType,
+    get_custom_encoding_candidates,
+)
+from meld.ui.findbar import FindBar
+from meld.ui.util import (
+    make_multiobject_property_action,
+    map_widgets_into_lists,
+)
+from meld.undo import UndoSequence
+
+log = logging.getLogger(__name__)
+
+
+class FourDiff(Gtk.HBox, MeldDoc):
+    """Four way comparison of text files"""
+
+    __gtype_name__ = "FourDiff"
+
+    close_signal = MeldDoc.close_signal
+    create_diff_signal = MeldDoc.create_diff_signal
+    file_changed_signal = MeldDoc.file_changed_signal
+    label_changed = MeldDoc.label_changed
+    move_diff = MeldDoc.move_diff
+    tab_state_changed = MeldDoc.tab_state_changed
+
+    __gsettings_bindings_view__ = (
+        ('ignore-blank-lines', 'ignore-blank-lines'),
+        ('show-overview-map', 'show-overview-map'),
+        ('overview-map-style', 'overview-map-style'),
+    )
+
+    ignore_blank_lines = GObject.Property(
+        type=bool,
+        nick="Ignore blank lines",
+        blurb="Whether to ignore blank lines when comparing file contents",
+        default=False,
+    )
+    show_overview_map = GObject.Property(type=bool, default=True)
+    overview_map_style = GObject.Property(type=str, default='chunkmap')
+
+    __gsignals__ = {
+        'next-conflict-changed': (
+            GObject.SignalFlags.RUN_FIRST, None, (bool, bool)),
+    }
+
+    action_mode = GObject.Property(
+        type=int,
+        nick='Action mode for chunk change actions',
+        default=ActionMode.Replace,
+    )
+
+    lock_scrolling = GObject.Property(
+        type=bool,
+        nick='Lock scrolling of all panes',
+        default=False,
+    )
+
+    def __init__(self):
+        super().__init__()
+        # FIXME:
+        # See FileDiff.__init__, which calls this an "unimaginable hack".
+        # I don't really understand the issue. It mentions Gtk.Template, which we
+        # don't inherit from, so perhaps this could be fixed here.
+        MeldDoc.__init__(self)
+        bind_settings(self)
+
+        # Manually handle GAction additions
+        actions = (
+            # ('add-sync-point', self.add_sync_point),
+            # ('remove-sync-point', self.remove_sync_point),
+            # ('clear-sync-point', self.clear_sync_points),
+            # ('copy', self.action_copy),
+            # ('copy-full-path', self.action_copy_full_path),
+            # ('cut', self.action_cut),
+            # ('file-previous-conflict', self.action_previous_conflict),
+            # ('file-next-conflict', self.action_next_conflict),
+            # ('file-push-left', self.action_push_change_left),
+            # ('file-push-right', self.action_push_change_right),
+            # ('file-pull-left', self.action_pull_change_left),
+            # ('file-pull-right', self.action_pull_change_right),
+            # ('file-copy-left-up', self.action_copy_change_left_up),
+            # ('file-copy-right-up', self.action_copy_change_right_up),
+            # ('file-copy-left-down', self.action_copy_change_left_down),
+            # ('file-copy-right-down', self.action_copy_change_right_down),
+            # ('file-delete', self.action_delete_change),
+            # ('find', self.action_find),
+            # ('find-next', self.action_find_next),
+            # ('find-previous', self.action_find_previous),
+            # ('find-replace', self.action_find_replace),
+            # ('format-as-patch', self.action_format_as_patch),
+            # ('go-to-line', self.action_go_to_line),
+            # ('merge-all-left', self.action_pull_all_changes_left),
+            # ('merge-all-right', self.action_pull_all_changes_right),
+            # ('merge-all', self.action_merge_all_changes),
+            # ('next-change', self.action_next_change),
+            # ('next-pane', self.action_next_pane),
+            # ('open-external', self.action_open_external),
+            # ('open-folder', self.action_open_folder),
+            # ('paste', self.action_paste),
+            # ('previous-change', self.action_previous_change),
+            # ('previous-pane', self.action_prev_pane),
+            # ('redo', self.action_redo),
+            # ('refresh', self.action_refresh),
+            # ('revert', self.action_revert),
+            # ('save', self.action_save),
+            # ('save-all', self.action_save_all),
+            # ('save-as', self.action_save_as),
+            # ('undo', self.action_undo),
+            # ('swap-2-panes', self.action_swap),
+            ('toggle-fourdiff-view', self.action_toggle_view),
+        )
+        for name, callback in actions:
+            action = Gio.SimpleAction.new(name, None)
+            action.connect('activate', callback)
+            self.view_action_group.add_action(action)
+
+        self.diff0 = FileDiff(2)
+        self.scheduler.add_scheduler(self.diff0.scheduler)
+        # self.diff0.force_readonly = [True, True]
+        # self.grid0.attach(self.diff0.widget, left=0, top=0, width=2, height=1)
+        self.add(self.diff0)
+
+        self.diff1 = FileDiff(2)
+        self.scheduler.add_scheduler(self.diff1.scheduler)
+        # self.diff1.force_readonly = [True, True]
+        # self.grid1.attach(self.label0, left=0, top=0, width=1, height=1)
+        # self.grid1.attach(self.diff1.widget, left=1, top=0, width=2, height=1)
+        # self.grid1.attach(self.label1, left=3, top=0, width=1, height=1)
+        self.add(self.diff1)
+
+        self.diff2 = FileDiff(2)
+        self.scheduler.add_scheduler(self.diff2.scheduler)
+        # self.diff2.force_readonly = [True, False]
+        self.undosequence = self.diff2.undosequence
+        # self.actiongroup = self.diff2.actiongroup
+        # self.grid0.attach(self.diff2.widget, left=2, top=0, width=2, height=1)
+        self.add(self.diff2)
+
+        self.diffs = [self.diff0, self.diff1, self.diff2]
+        # self.have_next_diffs = [(False, False) for _ in self.diffs]
+        # for diff in self.diffs:
+        #     diff.connect("next-diff-changed", self.on_have_next_diff_changed)
+
+        # self.grid0.connect("set-focus-child", self.on_grid0_set_focus_child)
+
+        # self.grid0.show()
+        # self.grid1.show()
+        self.show()
+
+        self.files = None
+
+        self._keep = []
+        self.connect_scrolledwindows()
+
+    def set_files(self, files):
+        """Load the given files
+
+        If an element is None, the text of a pane is left as is.
+        """
+        assert len(files) == 4
+        self.files = files
+        self.diff0.set_files(files[:2])
+        self.diff1.set_files(files[1:3])
+        self.diff2.set_files(files[2:])
+
+    def connect_scrolledwindows(self):
+        sws = [self.diff0.scrolledwindow[1], self.diff1.scrolledwindow[0],
+               self.diff1.scrolledwindow[1], self.diff2.scrolledwindow[0]]
+        vadjs = [sw.get_vadjustment() for sw in sws]
+        hadjs = [sw.get_hadjustment() for sw in sws]
+        # We keep the references because otherwise we get uninitialized
+        # references in the callbacks
+        self._keep.extend([vadjs, hadjs])
+
+        def connect(adj0, adj1):
+            adj0.connect("value-changed", self.on_adj_changed, adj1)
+            adj1.connect("value-changed", self.on_adj_changed, adj0)
+        connect(vadjs[0], vadjs[1])
+        connect(hadjs[0], hadjs[1])
+        connect(vadjs[2], vadjs[3])
+        connect(hadjs[2], hadjs[3])
+
+    def action_toggle_view(self, *args):
+        print('toggle view called')
+    
+    @staticmethod
+    def on_adj_changed(me, other):
+        v = me.get_value()
+        if other.get_value() != v:
+            other.set_value(v)
+
+    def on_delete_event(self):
+        self.emit('close', 0)
+        return Gtk.ResponseType.OK
+
+    def get_comparison(self):
+        # TODO
+        return RecentType.Merge, []
+        uris = [b.data.gfile for b in self.textbuffer[:self.num_panes]]
+
+        if self.comparison_mode == FileComparisonMode.AutoMerge:
+            comparison_type = RecentType.Merge
+        else:
+            comparison_type = RecentType.File
+
+        return comparison_type, uris
+

--- a/meld/fourdiff.py
+++ b/meld/fourdiff.py
@@ -217,6 +217,13 @@ class FourDiff(Gtk.Stack, MeldDoc):
         self._keep = []
         self.connect_scrolledwindows()
 
+    @staticmethod
+    def _set_read_only(diff, panes):
+        for pane in panes:
+            buf = diff.textbuffer[pane]
+            buf.data.force_read_only = True
+            diff.update_buffer_writable(buf)
+    
     def set_files(self, files):
         """Load the given files
 
@@ -225,8 +232,11 @@ class FourDiff(Gtk.Stack, MeldDoc):
         assert len(files) == 4
         self.files = files
         self.diff0.set_files(files[:2])
+        self._set_read_only(self.diff0, [0, 1])
         self.diff1.set_files(files[1:3])
+        self._set_read_only(self.diff1, [0, 1])
         self.diff2.set_files(files[2:])
+        self._set_read_only(self.diff2, [0])
 
     def connect_scrolledwindows(self):
         sws = [self.diff0.scrolledwindow[1], self.diff1.scrolledwindow[0],

--- a/meld/fourdiff.py
+++ b/meld/fourdiff.py
@@ -118,56 +118,6 @@ class FourDiff(Gtk.Stack, MeldDoc):
         MeldDoc.__init__(self)
         bind_settings(self)
 
-        # Manually handle GAction additions
-        actions = (
-            # ('add-sync-point', self.add_sync_point),
-            # ('remove-sync-point', self.remove_sync_point),
-            # ('clear-sync-point', self.clear_sync_points),
-            # ('copy', self.action_copy),
-            # ('copy-full-path', self.action_copy_full_path),
-            # ('cut', self.action_cut),
-            # ('file-previous-conflict', self.action_previous_conflict),
-            # ('file-next-conflict', self.action_next_conflict),
-            # ('file-push-left', self.action_push_change_left),
-            # ('file-push-right', self.action_push_change_right),
-            # ('file-pull-left', self.action_pull_change_left),
-            # ('file-pull-right', self.action_pull_change_right),
-            # ('file-copy-left-up', self.action_copy_change_left_up),
-            # ('file-copy-right-up', self.action_copy_change_right_up),
-            # ('file-copy-left-down', self.action_copy_change_left_down),
-            # ('file-copy-right-down', self.action_copy_change_right_down),
-            # ('file-delete', self.action_delete_change),
-            # ('find', self.action_find),
-            # ('find-next', self.action_find_next),
-            # ('find-previous', self.action_find_previous),
-            # ('find-replace', self.action_find_replace),
-            # ('format-as-patch', self.action_format_as_patch),
-            # ('go-to-line', self.action_go_to_line),
-            # ('merge-all-left', self.action_pull_all_changes_left),
-            # ('merge-all-right', self.action_pull_all_changes_right),
-            # ('merge-all', self.action_merge_all_changes),
-            # ('next-change', self.action_next_change),
-            # ('next-pane', self.action_next_pane),
-            # ('open-external', self.action_open_external),
-            # ('open-folder', self.action_open_folder),
-            # ('paste', self.action_paste),
-            # ('previous-change', self.action_previous_change),
-            # ('previous-pane', self.action_prev_pane),
-            # ('redo', self.action_redo),
-            # ('refresh', self.action_refresh),
-            # ('revert', self.action_revert),
-            # ('save', self.action_save),
-            # ('save-all', self.action_save_all),
-            # ('save-as', self.action_save_as),
-            # ('undo', self.action_undo),
-            # ('swap-2-panes', self.action_swap),
-            ('toggle-fourdiff-view', self.action_toggle_view),
-        )
-        for name, callback in actions:
-            action = Gio.SimpleAction.new(name, None)
-            action.connect('activate', callback)
-            self.view_action_group.add_action(action)
-
         self.grid0 = Gtk.Grid()
         self.grid0.set_row_homogeneous(True)
         self.grid0.set_column_homogeneous(True)
@@ -205,6 +155,56 @@ class FourDiff(Gtk.Stack, MeldDoc):
         #     diff.connect("next-diff-changed", self.on_have_next_diff_changed)
 
         # self.grid0.connect("set-focus-child", self.on_grid0_set_focus_child)
+
+        # Manually handle GAction additions
+        actions = (
+            # ('add-sync-point', self.add_sync_point),
+            # ('remove-sync-point', self.remove_sync_point),
+            # ('clear-sync-point', self.clear_sync_points),
+            # ('copy', self.action_copy),
+            # ('copy-full-path', self.action_copy_full_path),
+            # ('cut', self.action_cut),
+            # ('file-previous-conflict', self.action_previous_conflict),
+            # ('file-next-conflict', self.action_next_conflict),
+            # ('file-push-left', self.action_push_change_left),
+            # ('file-push-right', self.action_push_change_right),
+            # ('file-pull-left', self.action_pull_change_left),
+            # ('file-pull-right', self.action_pull_change_right),
+            # ('file-copy-left-up', self.action_copy_change_left_up),
+            # ('file-copy-right-up', self.action_copy_change_right_up),
+            # ('file-copy-left-down', self.action_copy_change_left_down),
+            # ('file-copy-right-down', self.action_copy_change_right_down),
+            # ('file-delete', self.action_delete_change),
+            ('find', self.action_find),
+            # ('find-next', self.action_find_next),
+            # ('find-previous', self.action_find_previous),
+            # ('find-replace', self.action_find_replace),
+            # ('format-as-patch', self.action_format_as_patch),
+            # ('go-to-line', self.action_go_to_line),
+            # ('merge-all-left', self.action_pull_all_changes_left),
+            # ('merge-all-right', self.action_pull_all_changes_right),
+            # ('merge-all', self.action_merge_all_changes),
+            # ('next-change', self.action_next_change),
+            # ('next-pane', self.action_next_pane),
+            # ('open-external', self.action_open_external),
+            # ('open-folder', self.action_open_folder),
+            # ('paste', self.action_paste),
+            # ('previous-change', self.action_previous_change),
+            # ('previous-pane', self.action_prev_pane),
+            # ('redo', self.action_redo),
+            # ('refresh', self.action_refresh),
+            # ('revert', self.action_revert),
+            # ('save', self.action_save),
+            # ('save-all', self.action_save_all),
+            # ('save-as', self.action_save_as),
+            ('undo', self.diff2.action_undo),
+            # ('swap-2-panes', self.action_swap),
+            ('toggle-fourdiff-view', self.action_toggle_view),
+        )
+        for name, callback in actions:
+            action = Gio.SimpleAction.new(name, None)
+            action.connect('activate', callback)
+            self.view_action_group.add_action(action)
 
         self.label0.show()
         self.label1.show()
@@ -261,6 +261,25 @@ class FourDiff(Gtk.Stack, MeldDoc):
         else:
             self.set_visible_child_name('grid1')
         # self.on_active_diff_changed()
+    
+    def get_active_diff(self):
+        name = self.get_visible_child_name()
+        if name == 'grid0':
+            if self.diff0.get_focus_child() is not None:
+                return self.diff0
+            elif self.diff2.get_focus_child() is not None:
+                return self.diff2
+            else:
+                return None
+        elif name == 'grid1':
+            return self.diff1
+        else:
+            return None
+
+    def action_find(self, *args):
+        diff = self.get_active_diff()
+        if diff:
+            diff.action_find(*args)
     
     @staticmethod
     def on_adj_changed(me, other):

--- a/meld/fourdiff.py
+++ b/meld/fourdiff.py
@@ -11,60 +11,116 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# TODO: next/pervious buttons are not enabled. Probably need to forward events
 
-import copy
-import functools
 import logging
-import math
-from enum import Enum
-from typing import Optional, Tuple, Type
 
-from gi.repository import Gdk, Gio, GLib, GObject, Gtk, GtkSource
+from gi.repository import Gio, GLib, GObject, Gtk
 
-# TODO: Don't from-import whole modules
-from meld import misc
-from meld.conf import _
-from meld.const import (
-    NEWLINES,
-    TEXT_FILTER_ACTION_FORMAT,
-    ActionMode,
-    ChunkAction,
-    FileComparisonMode,
-    FileLoadError,
-)
-from meld.externalhelpers import open_files_external
+from meld.const import TEXT_FILTER_ACTION_FORMAT, ActionMode
 from meld.filediff import FileDiff
-from meld.gutterrendererchunk import GutterRendererChunkLines
-from meld.iohelpers import find_shared_parent_path, prompt_save_filename
-from meld.matchers.diffutil import Differ, merged_chunk_order
-from meld.matchers.helpers import CachedSequenceMatcher
-from meld.matchers.merge import AutoMergeDiffer, Merger
-from meld.meldbuffer import (
-    BufferDeletionAction,
-    BufferInsertionAction,
-    BufferLines,
-    MeldBufferState,
-)
-from meld.melddoc import ComparisonState, MeldDoc
-from meld.menuhelpers import replace_menu_section
-from meld.misc import user_critical, with_focused_pane
-from meld.patchdialog import PatchDialog
+from meld.melddoc import MeldDoc
 from meld.recent import RecentType
-from meld.settings import bind_settings, get_meld_settings
-from meld.sourceview import (
-    LanguageManager,
-    TextviewLineAnimationType,
-    get_custom_encoding_candidates,
-)
-from meld.ui.findbar import FindBar
-from meld.ui.util import (
-    make_multiobject_property_action,
-    map_widgets_into_lists,
-)
-from meld.undo import UndoSequence
+from meld.settings import MeldSettings, bind_settings, get_meld_settings
 
 log = logging.getLogger(__name__)
+
+# These lists contain all the actions in FileDiff, except for the actions generated for each filter.
+# Those lists are verified by _verify_action_lists()
+
+FWD_TO_ACTIVE_ACTIONS = [
+    'add-sync-point',
+    'remove-sync-point',
+    'clear-sync-point',
+    'copy',
+    'copy-full-path',
+    'cut',
+    'file-previous-conflict',
+    'file-next-conflict',
+    'file-push-left',
+    'file-push-right',
+    'file-pull-left',
+    'file-pull-right',
+    'file-copy-left-up',
+    'file-copy-right-up',
+    'file-copy-left-down',
+    'file-copy-right-down',
+    'file-delete',
+    'find',
+    'find-next',
+    'find-previous',
+    'find-replace',
+    'format-as-patch',
+    'go-to-line',
+    'merge-all-left',
+    'merge-all-right',
+    'merge-all',
+    'next-change',
+    'next-pane',
+    'open-external',
+    'open-folder',
+    'paste',
+    'previous-change',
+    'previous-pane',
+    'redo',
+    'undo',
+]
+
+FWD_TO_ALL_ACTIONS = [
+    'refresh',
+    'revert',
+    'save',
+    'save-all',
+]
+
+DISABLED_ACTIONS = [
+    # save-as is disabled since we don't want filenames to change
+    'save-as',
+    # swap-2-panes is disabled since reversing all panes would require more work, and I
+    # currently don't see why it should be useful.
+    'swap-2-panes',
+]
+
+PROPERTY_ACTIONS = {
+    'show-overview-map': 'show-overview-map',
+    'lock-scrolling': 'lock_scrolling',
+}
+
+STATE_ACTIONS = {
+    'text-filter': False,
+}
+
+# In addition to those, there are stateful actions created for each text filter
+def _get_text_filter_action_names(meld_settings: MeldSettings) -> list[str]:
+    # All action names are known, except for those for enabling/disabling text filters.
+    # We generate those names in the same way as FileDiff.create_text_filters()
+    n_text_filters = len(meld_settings.text_filters)
+    return [TEXT_FILTER_ACTION_FORMAT.format(i) for i in range(n_text_filters)]
+
+
+def _get_diff_actions(diff: FileDiff) -> tuple[set[str], set[str]]:
+    """Get all actions in a FileDiff, stateless and stateful"""
+    all_action_names = set(diff.view_action_group.list_actions())
+    stateful_action_names = set()
+    stateless_action_names = set()
+    for action_name in all_action_names:
+        state = diff.view_action_group.get_action_state(action_name)
+        if state is None:
+            stateless_action_names.add(action_name)
+        else:
+            # Assert all stateful actions have type bool
+            assert state.get_type_string() == 'b'
+            stateful_action_names.add(action_name)
+    return stateless_action_names, stateful_action_names
+
+
+def _verify_action_lists(diff: FileDiff):
+    """Assert that the action lists cover all the actions in the FileDiff."""
+    stateless_names, stateful_names = _get_diff_actions(diff)
+    expected_stateless_names = FWD_TO_ACTIVE_ACTIONS + FWD_TO_ALL_ACTIONS + DISABLED_ACTIONS
+    assert set(expected_stateless_names) == stateless_names
+    text_filter_action_names = _get_text_filter_action_names(get_meld_settings())
+    expected_stateful_names = list(PROPERTY_ACTIONS) + list(STATE_ACTIONS) + text_filter_action_names
+    assert set(expected_stateful_names) == stateful_names
 
 
 class FourDiff(Gtk.Stack, MeldDoc):
@@ -128,15 +184,13 @@ class FourDiff(Gtk.Stack, MeldDoc):
         self.grid1.set_row_homogeneous(True)
         self.grid1.set_column_homogeneous(True)
         self.add_named(self.grid1, "grid1")
-        
+
         self.diff0 = FileDiff(2)
         self.scheduler.add_scheduler(self.diff0.scheduler)
-        # TODO: self.diff0.force_readonly = [True, True]
         self.grid0.attach(self.diff0, left=0, top=0, width=2, height=1)
 
         self.diff1 = FileDiff(2)
         self.scheduler.add_scheduler(self.diff1.scheduler)
-        # TODO: self.diff1.force_readonly = [True, True]
         # The labels are used to fill the empty spaces in the grid
         self.label0 = Gtk.Label()
         self.label1 = Gtk.Label()
@@ -146,67 +200,31 @@ class FourDiff(Gtk.Stack, MeldDoc):
 
         self.diff2 = FileDiff(2)
         self.scheduler.add_scheduler(self.diff2.scheduler)
-        # TODO: self.diff2.force_readonly = [True, False]
         self.undosequence = self.diff2.undosequence
-        # TODO: self.actiongroup = self.diff2.actiongroup
         self.grid0.attach(self.diff2, left=2, top=0, width=2, height=1)
 
         self.diffs = [self.diff0, self.diff1, self.diff2]
-        # self.have_next_diffs = [(False, False) for _ in self.diffs]
-        # for diff in self.diffs:
-        #     diff.connect("next-diff-changed", self.on_have_next_diff_changed)
 
-        # self.grid0.connect("set-focus-child", self.on_grid0_set_focus_child)
+        # We always have an active FileDiff, which is self.diffs[self.active_diff_i].
+        # When Showing 1 FileDiff, it is the active diff. When showing 2 FileDiffs, it's the one which last
+        # received focus.
+        self.active_diff_i = 2
+        self.active_diff = self.diffs[self.active_diff_i]
+        self.is_showing_2_diffs = True
+        self.active_diff_i_when_showing_2_diffs = 2
 
-        # Manually handle GAction additions
-        actions = (
-            # ('add-sync-point', self.add_sync_point),
-            # ('remove-sync-point', self.remove_sync_point),
-            # ('clear-sync-point', self.clear_sync_points),
-            ('copy', self.diff2.action_copy),
-            ('copy-full-path', self._fwd2active(FileDiff.action_copy_full_path)),
-            ('cut', self._fwd2active(FileDiff.action_cut)),
-            ('file-previous-conflict', self._fwd2active(FileDiff.action_previous_conflict)),
-            ('file-next-conflict', self._fwd2active(FileDiff.action_next_conflict)),
-            # ('file-push-left', self.action_push_change_left),
-            # ('file-push-right', self.action_push_change_right),
-            # ('file-pull-left', self.action_pull_change_left),
-            # ('file-pull-right', self.action_pull_change_right),
-            # ('file-copy-left-up', self.action_copy_change_left_up),
-            # ('file-copy-right-up', self.action_copy_change_right_up),
-            # ('file-copy-left-down', self.action_copy_change_left_down),
-            # ('file-copy-right-down', self.action_copy_change_right_down),
-            # ('file-delete', self.action_delete_change),
-            ('find', self._fwd2active('action_find')),
-            # ('find-next', self.action_find_next),
-            # ('find-previous', self.action_find_previous),
-            # ('find-replace', self.action_find_replace),
-            # ('format-as-patch', self.action_format_as_patch),
-            # ('go-to-line', self.action_go_to_line),
-            # ('merge-all-left', self.action_pull_all_changes_left),
-            # ('merge-all-right', self.action_pull_all_changes_right),
-            # ('merge-all', self.action_merge_all_changes),
-            # ('next-change', self.action_next_change),
-            # ('next-pane', self.action_next_pane),
-            # ('open-external', self.action_open_external),
-            # ('open-folder', self.action_open_folder),
-            # ('paste', self.action_paste),
-            # ('previous-change', self.action_previous_change),
-            # ('previous-pane', self.action_prev_pane),
-            # ('redo', self.action_redo),
-            ('refresh', self._fwd2all(FileDiff.action_refresh)),
-            # ('revert', self.action_revert),
-            # ('save', self.action_save),
-            # ('save-all', self.action_save_all),
-            # ('save-as', self.action_save_as),
-            ('undo', self.diff2.action_undo),
-            # ('swap-2-panes', self.action_swap),
-            ('toggle-fourdiff-view', self.action_toggle_view),
-        )
-        for name, callback in actions:
-            action = Gio.SimpleAction.new(name, None)
-            action.connect('activate', callback)
-            self.view_action_group.add_action(action)
+        for diff_i in [0, 2]:
+            for tv in self.diffs[diff_i].textview:
+                tv.connect('focus-in-event', self.on_textview_focus_in_event, diff_i)
+
+        # Each FileDiff emits next-conflict-changed(bool, bool), which means, is there a prev and next conflict.
+        # We keep the current status for each of the FileDiffs, and emit the status for the active FileDiff.
+        self.cur_next_conflict = (False, False)
+        self.diff_next_conflicts = [(False, False) for _ in self.diffs]
+        for diff in self.diffs:
+            diff.connect("next-conflict-changed", self.on_diff_next_conflict_changed)
+
+        self._init_actions()
 
         self.label0.show()
         self.label1.show()
@@ -216,43 +234,106 @@ class FourDiff(Gtk.Stack, MeldDoc):
 
         self.files = None
 
-        self._keep = []
         self.connect_scrolledwindows()
 
-    def get_active_diff(self):
-        name = self.get_visible_child_name()
-        if name == 'grid0':
-            if self.diff0.get_focus_child() is not None:
-                return self.diff0
-            elif self.diff2.get_focus_child() is not None:
-                return self.diff2
-            else:
-                return None
-        elif name == 'grid1':
-            return self.diff1
-        else:
-            return None
-    
-    def _fwd2active(self, method):
-        def f(*args):
-            diff = self.get_active_diff()
-            if diff:
-                method(diff, *args)
-        return f
-    
-    def _fwd2all(self, method):
-        def f(*args):
-            for diff in self.diffs:
-                method(diff, *args)
-        return f
+    def _init_actions(self):
+        """
+        Create actions to forward to the FileDiffs.
+        Most actions are forwarded to the active FileDiff, some are forwarded to all.
+        """
+        for diff in self.diffs:
+            _verify_action_lists(diff)
+
+        action = Gio.SimpleAction.new('toggle-fourdiff-view')
+        action.connect('activate', self.action_toggle_view)
+        self.view_action_group.add_action(action)
+
+        for name in FWD_TO_ACTIVE_ACTIONS:
+            action = Gio.SimpleAction.new(name, None)
+            action.connect('activate', self.on_fwd_to_active_action_activate)
+            self.view_action_group.add_action(action)
+
+        for name in FWD_TO_ALL_ACTIONS:
+            action = Gio.SimpleAction.new(name, None)
+            action.connect('activate', self.on_fwd_to_all_action_activate)
+            self.view_action_group.add_action(action)
+
+        for action_name, prop_name in PROPERTY_ACTIONS.items():
+            action = Gio.PropertyAction.new(action_name, self, prop_name)
+            action.connect('notify::state', self.on_property_action_change_state)
+            self.view_action_group.add_action(action)
+
+        for action_name, state in STATE_ACTIONS.items():
+            action = Gio.SimpleAction.new_stateful(name, None, GLib.Variant.new_boolean(state))
+            action.connect('activate', self.on_fwd_to_all_action_activate)
+            action.connect('change-state', self.on_action_change_state)
+            self.view_action_group.add_action(action)
+
+        # TODO: text filter actions
+
+        for diff_i, diff in enumerate(self.diffs):
+            diff.view_action_group.connect('action-enabled-changed', self.on_diff_action_enabled_changed, diff_i)
+
+    def on_fwd_to_active_action_activate(self, action, user_data):
+        self.active_diff.view_action_group.activate_action(action.get_name(), user_data)
+
+    def on_fwd_to_all_action_activate(self, action, user_data):
+        for diff in self.diffs:
+            diff.view_action_group.activate_action(action.get_name(), user_data)
+
+    def on_diff_action_enabled_changed(self, _action_group, name, enabled, diff_i):
+        if diff_i == self.active_diff_i:
+            self.view_action_group.lookup(name).set_enabled(enabled)
+
+    def on_property_action_change_state(self, paction, _param_spec):
+        for diff in self.diffs:
+            diff.view_action_group.change_action_state(paction.props.name, paction.props.state)
+
+    def on_action_change_state(self, action, state):
+        for diff in self.diffs:
+            diff.view_action_group.change_action_state(action.get_name(), state)
+
+    def _update_active_diff(self):
+        """
+        Update self.active_diff_i based on self.active_diff_i_when_showing_2_diffs and self.is_showing_2_diffs.
+        If changed, send signals and update actions accordingly.
+        """
+        active_diff_i = self.active_diff_i_when_showing_2_diffs if self.is_showing_2_diffs else 1
+        if active_diff_i != self.active_diff_i:
+            self.active_diff_i = active_diff_i
+            self.active_diff = self.diffs[active_diff_i]
+
+            next_conflict = self.diff_next_conflicts[active_diff_i]
+            if next_conflict != self.cur_next_conflict:
+                self.cur_next_conflict = next_conflict
+                have_prev, have_next = next_conflict
+                self.emit("next-conflict-changed", have_prev, have_next)
+
+            diff_view_action_group = self.active_diff.view_action_group
+            for name in FWD_TO_ACTIVE_ACTIONS:
+                self.view_action_group.lookup(name).set_enabled(diff_view_action_group.lookup(name).get_enabled())
+
+    def on_textview_focus_in_event(self, _textbuffer, _event, diff_i):
+        self.active_diff_i_when_showing_2_diffs = diff_i
+        self._update_active_diff()
+
+    def on_diff_next_conflict_changed(self, diff, have_prev, have_next):
+        diff_i = self.diffs.index(diff)
+        next_conflict = (have_prev, have_next)
+        self.diff_next_conflicts[diff_i] = next_conflict
+        if diff_i == self.active_diff_i:
+            if self.cur_next_conflict != next_conflict:
+                self.cur_next_conflict = next_conflict
+                self.emit("next-conflict-changed", have_prev, have_next)
 
     @staticmethod
     def _set_read_only(diff, panes):
+        # A helper function for set_files()
         for pane in panes:
             buf = diff.textbuffer[pane]
             buf.data.force_read_only = True
             diff.update_buffer_writable(buf)
-    
+
     def set_files(self, files):
         """Load the given files
 
@@ -261,41 +342,37 @@ class FourDiff(Gtk.Stack, MeldDoc):
         assert len(files) == 4
         self.files = files
         self.diff0.set_files(files[:2])
-        self._set_read_only(self.diff0, [0, 1])
+        self._set_read_only(self.diff0, [1])
         self.diff1.set_files(files[1:3])
         self._set_read_only(self.diff1, [0, 1])
         self.diff2.set_files(files[2:])
         self._set_read_only(self.diff2, [0])
+
+    @staticmethod
+    def _on_adj_changed(me, other):
+        # A helper function for connect_scrolledwindows()
+        v = me.get_value()
+        if other.get_value() != v:
+            other.set_value(v)
 
     def connect_scrolledwindows(self):
         sws = [self.diff0.scrolledwindow[1], self.diff1.scrolledwindow[0],
                self.diff1.scrolledwindow[1], self.diff2.scrolledwindow[0]]
         vadjs = [sw.get_vadjustment() for sw in sws]
         hadjs = [sw.get_hadjustment() for sw in sws]
-        # We keep the references because otherwise we get uninitialized
-        # references in the callbacks
-        self._keep.extend([vadjs, hadjs])
 
         def connect(adj0, adj1):
-            adj0.connect("value-changed", self.on_adj_changed, adj1)
-            adj1.connect("value-changed", self.on_adj_changed, adj0)
+            adj0.connect("value-changed", self._on_adj_changed, adj1)
+            adj1.connect("value-changed", self._on_adj_changed, adj0)
         connect(vadjs[0], vadjs[1])
         connect(hadjs[0], hadjs[1])
         connect(vadjs[2], vadjs[3])
         connect(hadjs[2], hadjs[3])
 
     def action_toggle_view(self, *args):
-        if self.get_visible_child_name() == 'grid1':
-            self.set_visible_child_name('grid0')
-        else:
-            self.set_visible_child_name('grid1')
-        # self.on_active_diff_changed()
-    
-    @staticmethod
-    def on_adj_changed(me, other):
-        v = me.get_value()
-        if other.get_value() != v:
-            other.set_value(v)
+        self.is_showing_2_diffs = not self.is_showing_2_diffs
+        self.set_visible_child_name('grid0' if self.is_showing_2_diffs else 'grid1')
+        self._update_active_diff()
 
     def on_delete_event(self):
         self.emit('close', 0)
@@ -312,4 +389,3 @@ class FourDiff(Gtk.Stack, MeldDoc):
         #     comparison_type = RecentType.File
 
         # return comparison_type, uris
-

--- a/meld/fourdiff.py
+++ b/meld/fourdiff.py
@@ -21,6 +21,7 @@ from meld.conf import _
 from meld.const import TEXT_FILTER_ACTION_FORMAT, ActionMode
 from meld.filediff import FileDiff
 from meld.melddoc import MeldDoc
+from meld.recent import RecentType
 from meld.settings import bind_settings, get_meld_settings
 
 log = logging.getLogger(__name__)
@@ -373,6 +374,11 @@ class FourDiff(Gtk.Stack, MeldDoc):
 
     def on_diff_label_changed(self, _diff, _label_text, _tooltip_text):
         self.recompute_label()
+
+    def get_comparison(self):
+        buffers = self.diff0.textbuffer[:2] + self.diff2.textbuffer[:2]
+        uris = [b.data.gfile for b in buffers]
+        return RecentType.FourDiff, uris
 
     @staticmethod
     def _on_adj_changed(me, other):

--- a/meld/fourdiff.py
+++ b/meld/fourdiff.py
@@ -65,7 +65,7 @@ from meld.undo import UndoSequence
 log = logging.getLogger(__name__)
 
 
-class FourDiff(Gtk.HBox, MeldDoc):
+class FourDiff(Gtk.Stack, MeldDoc):
     """Four way comparison of text files"""
 
     __gtype_name__ = "FourDiff"
@@ -168,27 +168,36 @@ class FourDiff(Gtk.HBox, MeldDoc):
             action.connect('activate', callback)
             self.view_action_group.add_action(action)
 
+        self.grid0 = Gtk.Grid()
+        self.grid0.set_row_homogeneous(True)
+        self.grid0.set_column_homogeneous(True)
+        self.add_named(self.grid0, "grid0")
+        self.grid1 = Gtk.Grid()
+        self.grid1.set_row_homogeneous(True)
+        self.grid1.set_column_homogeneous(True)
+        self.add_named(self.grid1, "grid1")
+        
         self.diff0 = FileDiff(2)
         self.scheduler.add_scheduler(self.diff0.scheduler)
-        # self.diff0.force_readonly = [True, True]
-        # self.grid0.attach(self.diff0.widget, left=0, top=0, width=2, height=1)
-        self.add(self.diff0)
+        # TODO: self.diff0.force_readonly = [True, True]
+        self.grid0.attach(self.diff0, left=0, top=0, width=2, height=1)
 
         self.diff1 = FileDiff(2)
         self.scheduler.add_scheduler(self.diff1.scheduler)
-        # self.diff1.force_readonly = [True, True]
-        # self.grid1.attach(self.label0, left=0, top=0, width=1, height=1)
-        # self.grid1.attach(self.diff1.widget, left=1, top=0, width=2, height=1)
-        # self.grid1.attach(self.label1, left=3, top=0, width=1, height=1)
-        self.add(self.diff1)
+        # TODO: self.diff1.force_readonly = [True, True]
+        # The labels are used to fill the empty spaces in the grid
+        self.label0 = Gtk.Label()
+        self.label1 = Gtk.Label()
+        self.grid1.attach(self.label0, left=0, top=0, width=1, height=1)
+        self.grid1.attach(self.diff1, left=1, top=0, width=2, height=1)
+        self.grid1.attach(self.label1, left=3, top=0, width=1, height=1)
 
         self.diff2 = FileDiff(2)
         self.scheduler.add_scheduler(self.diff2.scheduler)
-        # self.diff2.force_readonly = [True, False]
+        # TODO: self.diff2.force_readonly = [True, False]
         self.undosequence = self.diff2.undosequence
-        # self.actiongroup = self.diff2.actiongroup
-        # self.grid0.attach(self.diff2.widget, left=2, top=0, width=2, height=1)
-        self.add(self.diff2)
+        # TODO: self.actiongroup = self.diff2.actiongroup
+        self.grid0.attach(self.diff2, left=2, top=0, width=2, height=1)
 
         self.diffs = [self.diff0, self.diff1, self.diff2]
         # self.have_next_diffs = [(False, False) for _ in self.diffs]
@@ -197,8 +206,10 @@ class FourDiff(Gtk.HBox, MeldDoc):
 
         # self.grid0.connect("set-focus-child", self.on_grid0_set_focus_child)
 
-        # self.grid0.show()
-        # self.grid1.show()
+        self.label0.show()
+        self.label1.show()
+        self.grid0.show()
+        self.grid1.show()
         self.show()
 
         self.files = None
@@ -235,7 +246,11 @@ class FourDiff(Gtk.HBox, MeldDoc):
         connect(hadjs[2], hadjs[3])
 
     def action_toggle_view(self, *args):
-        print('toggle view called')
+        if self.get_visible_child_name() == 'grid1':
+            self.set_visible_child_name('grid0')
+        else:
+            self.set_visible_child_name('grid1')
+        # self.on_active_diff_changed()
     
     @staticmethod
     def on_adj_changed(me, other):

--- a/meld/fourdiff.py
+++ b/meld/fourdiff.py
@@ -21,7 +21,6 @@ from meld.conf import _
 from meld.const import TEXT_FILTER_ACTION_FORMAT, ActionMode
 from meld.filediff import FileDiff
 from meld.melddoc import MeldDoc
-from meld.recent import RecentType
 from meld.settings import bind_settings, get_meld_settings
 
 log = logging.getLogger(__name__)
@@ -415,15 +414,3 @@ class FourDiff(Gtk.Stack, MeldDoc):
         # TODO: check if there are still conflict markers
         self.emit('close', 0)
         return Gtk.ResponseType.OK
-
-    def get_comparison(self):
-        # TODO
-        return RecentType.Merge, []
-        # uris = [b.data.gfile for b in self.textbuffer[:self.num_panes]]
-
-        # if self.comparison_mode == FileComparisonMode.AutoMerge:
-        #     comparison_type = RecentType.Merge
-        # else:
-        #     comparison_type = RecentType.File
-
-        # return comparison_type, uris

--- a/meld/meldapp.py
+++ b/meld/meldapp.py
@@ -193,8 +193,8 @@ class MeldApp(Gtk.Application):
             ("", _("Start with an empty window")),
             ("<%s|%s>" % (_("file"), _("folder")),
              _("Start a version control comparison")),
-            ("<%s> <%s> [<%s>]" % ((_("file"),) * 3),
-             _("Start a 2- or 3-way file comparison")),
+            ("<%s> <%s> [<%s>] [<%s>]" % ((_("file"),) * 4),
+             _("Start a 2- or 3- or 4-way file comparison")),
             ("<%s> <%s> [<%s>]" % ((_("folder"),) * 3),
              _("Start a 2- or 3-way folder comparison")),
         ]

--- a/meld/meldapp.py
+++ b/meld/meldapp.py
@@ -300,11 +300,11 @@ class MeldApp(Gtk.Application):
             cleanup()
             return parser.exit_status
 
-        if len(args) > 3:
-            parser.local_error(_("too many arguments (wanted 0-3, got %d)") %
+        if len(args) > 4:
+            parser.local_error(_("too many arguments (wanted 0-4, got %d)") %
                                len(args))
-        elif options.auto_merge and len(args) < 3:
-            parser.local_error(_("can’t auto-merge less than 3 files"))
+        elif options.auto_merge and len(args) != 3:
+            parser.local_error(_("can only auto-merge 3 files"))
         elif options.auto_merge and any([os.path.isdir(f) for f in args]):
             parser.local_error(_("can’t auto-merge directories"))
 

--- a/meld/meldbuffer.py
+++ b/meld/meldbuffer.py
@@ -104,6 +104,7 @@ class MeldBufferData(GObject.GObject):
         self._label = None
         self._monitor = None
         self._sourcefile = None
+        self._force_read_only = False
         self.reset(gfile=None, state=MeldBufferState.EMPTY)
 
     def reset(self, gfile: Optional[Gio.File], state: MeldBufferState):
@@ -206,7 +207,17 @@ class MeldBufferData(GObject.GObject):
             return None
 
     @property
+    def force_read_only(self) -> bool:
+        return self._force_read_only
+    
+    @force_read_only.setter
+    def force_read_only(self, value: bool):
+        self._force_read_only = value
+    
+    @property
     def writable(self):
+        if self._force_read_only:
+            return False
         try:
             info = self.gfiletarget.query_info(
                 Gio.FILE_ATTRIBUTE_ACCESS_CAN_WRITE, 0, None)

--- a/meld/meldbuffer.py
+++ b/meld/meldbuffer.py
@@ -209,11 +209,11 @@ class MeldBufferData(GObject.GObject):
     @property
     def force_read_only(self) -> bool:
         return self._force_read_only
-    
+
     @force_read_only.setter
     def force_read_only(self, value: bool):
         self._force_read_only = value
-    
+
     @property
     def writable(self):
         if self._force_read_only:

--- a/meld/meldwindow.py
+++ b/meld/meldwindow.py
@@ -31,6 +31,7 @@ from meld.const import (
 )
 from meld.dirdiff import DirDiff
 from meld.filediff import FileDiff
+from meld.fourdiff import FourDiff
 from meld.imagediff import ImageDiff, files_are_images
 from meld.melddoc import ComparisonState, MeldDoc
 from meld.menuhelpers import replace_menu_section
@@ -433,6 +434,13 @@ class MeldWindow(Gtk.ApplicationWindow):
             return self.append_filediff(
                 gfiles, merge_output=merge_output, meta=meta)
 
+    def append_fourdiff(self, gfiles: Sequence[Optional[Gio.File]]):
+        assert len(gfiles) == 4
+        doc = FourDiff()
+        self._append_page(doc)
+        doc.set_files(gfiles)
+        return doc
+
     def append_vcview(self, location, auto_compare=False):
         doc = VcView()
         self._append_page(doc)
@@ -486,6 +494,10 @@ class MeldWindow(Gtk.ApplicationWindow):
         elif len(gfiles) in (2, 3):
             tab = self.append_diff(gfiles, auto_compare=auto_compare,
                                    auto_merge=auto_merge)
+        
+        elif len(gfiles) == 4:
+            tab = self.append_fourdiff(gfiles)
+
         if tab:
             recent_comparisons.add(tab)
             if focus:

--- a/meld/meldwindow.py
+++ b/meld/meldwindow.py
@@ -458,6 +458,7 @@ class MeldWindow(Gtk.ApplicationWindow):
             RecentType.File: self.append_filediff,
             RecentType.Folder: self.append_dirdiff,
             RecentType.Merge: self.append_filemerge,
+            RecentType.FourDiff: self.append_fourdiff,
             RecentType.VersionControl: self.append_vcview,
         }
         tab = comparison_method[comparison_type](gfiles)

--- a/meld/meldwindow.py
+++ b/meld/meldwindow.py
@@ -494,7 +494,7 @@ class MeldWindow(Gtk.ApplicationWindow):
         elif len(gfiles) in (2, 3):
             tab = self.append_diff(gfiles, auto_compare=auto_compare,
                                    auto_merge=auto_merge)
-        
+
         elif len(gfiles) == 4:
             tab = self.append_fourdiff(gfiles)
 

--- a/meld/recent.py
+++ b/meld/recent.py
@@ -46,6 +46,7 @@ class RecentType(enum.Enum):
     Folder = "Folder"
     VersionControl = "Version control"
     Merge = "Merge"
+    FourDiff = "FourDiff"
 
 
 class RecentFiles:

--- a/meld/resources/gtk/help-overlay.ui
+++ b/meld/resources/gtk/help-overlay.ui
@@ -130,6 +130,13 @@
                 <property name="title" translatable="yes" context="shortcut window">Swap left and right panes</property>
               </object>
             </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="action-name">view.toggle-fourdiff-view</property>
+                <property name="title" translatable="yes" context="shortcut window">Toggle Fourdiff view between viewing the A-B C-D diffs and viewing the B-C diff</property>
+              </object>
+            </child>
           </object>
         </child>
         <child>

--- a/meld/resources/gtk/menus.ui
+++ b/meld/resources/gtk/menus.ui
@@ -66,6 +66,10 @@
             <attribute name="label" translatable="yes">Swap Left and Right Panes</attribute>
             <attribute name="action">view.swap-2-panes</attribute>
           </item>
+          <item>
+            <attribute name="label" translatable="yes">Toggle Fourdiff View</attribute>
+            <attribute name="action">view.toggle-fourdiff-view</attribute>
+          </item>
         </section>
       </submenu>
       <submenu>


### PR DESCRIPTION
Hi!

This PR adds another diff view, called FourDiff. I have been using it for resolving merge conflicts since 2018 (see branch [fourdiff-old](https://github.com/noamraph/meld/tree/fourdiff-old)), and it helped me a lot - before I made it, resolving merge conflicts was a chore that I never fully understood how to do, and now it's usually pretty easy, and I feel confidence when resolving conflicts.

The key idea is that when merging/rebasing/cherry-picking/reverting, you want the diff between LOCAL and MERGED to be logically the same as the diff between BASE and REMOTE. The FourDiff view displays those two diffs side-by-side, which allows to visually verify that they are logically the same diff.

This is a new feature, so I'll be happy to get any feedback on it. I hope it can be added to Meld, since I think it can help others like it helped me.

To see it in action, I created a simple merge conflict example. You can see it like this:
```bash
cd /tmp
git clone https://github.com/noamraph/conflict-example.git
cd conflict-example
git merge origin/remove-greetings
# Shows: Automatic merge failed; fix conflicts and then commit the result.
git mergetool -t meld
```
It shows something like this:
![image](https://github.com/user-attachments/assets/dff55f0d-2bd0-49f9-ad24-bf2426da060a)
For me it is very confusing. In truth, there's no way to know what the result should be just from the two side panes.

To see the FourDiff view, checkout the `fourdiff` branch, add this to `~/.gitconfig`:
```
[mergetool "fourdiff"]
    cmd = /PATH/TO/meld/bin/meld "$REMOTE" "$BASE" "$LOCAL" "$MERGED"
```
And run:
```bash
git mergetool -t fourdiff
```
You get this (without the red arrows, of course):
![image](https://github.com/user-attachments/assets/04c101bd-c2ad-4384-abe5-22b345a48c6a)
The panes are, from left to right: REMOTE, BASE, LOCAL, MERGED. Resolving the merge means making the diff from LOCAL to MERGED be the same as the diff from BASE to REMOTE.

We can see that the diff between BASE and REMOTE removed the `name` arguments and the `print()` calls. It's easy to edit the right pane to do the same:
![image](https://github.com/user-attachments/assets/951a0a38-37e3-4270-aebf-261ee643946c)
What I really like about this view is that since the diffs appear side-by-side, it's immediately visible that the two diffs are logically the same.

Another feature that helps with understanding and resolving the merge conflict is the ability to switch the view to show the difference between BASE and LOCAL. If you press Ctrl-T (or click View->Toggle FourDiff View), you see this:
![image](https://github.com/user-attachments/assets/9103c41b-33da-409c-b5b4-82111e5181c9)
This shows the difference between BASE and LOCAL, which caused the merge conflict. We can see that the difference is adding the `c` argument to `multiply()`. This change needs to be preserved when resolving the conflict.

The implementation of FourDiff is quite simple - the FourDiff widget holds three FileDiff widgets:
1. REMOTE - BASE
2. BASE - LOCAL
3. LOCAL - MERGED

There are two views: In the first view, FileDiffs 1 and 3 are visible, and in the second view, FileDiff 2 is visible.

When one of the two BASE panes is scrolled, the other is scrolled to the same position, and so with the two LOCAL panes. This causes all panes to be scrolled together, since the two panes in all three FileDiffs are already scrolled together.

Note: I made only the rightmost pane (MERGED) editable. It is required that the shared panes will not be editable, so their text will remain in sync. It was possible to be more symmetric, and treat the leftmost and rightmost panes in the same way, allowing both to be editable. However, I preferred to break the symmetry and only make the rightmost pane editable. My main reason was that I made the "next conflict" and "previous conflict" actions go the the next and previous `<<<<<<<` in the right pane, so it already broke the symmetry. But this is open for debate.

What do you think? Can this be added, even as an experimental feature?

Thanks!
Noam